### PR TITLE
ENH: Carrier plots in one figure

### DIFF
--- a/pactools/utils/carrier.py
+++ b/pactools/utils/carrier.py
@@ -66,12 +66,29 @@ class Carrier:
         """
         Plots the impulse response and the transfer function of the filter.
         """
+        # validate figure
+        if fig is None:
+            fig_passed = False
+            fig, axes = plt.subplots(nrows=2)
+        else:
+            fig_passed = True
+            if not isinstance(fig, plt.Figure):
+                raise TypeError('fig must be matplotlib Figure, got {}'
+                                ' instead.'.format(type(fig)))
+            # test if is figure and has 2 axes
+            n_axes = len(fig.axes)
+            if n_axes < 2:
+                raise ValueError('Passed figure must have at least two axes'
+                                 ', given figure has {}.'.format(n_axes))
+            axes = fig.axes
+
         # compute periodogram
         fft_length = max(int(2 ** np.ceil(np.log2(self.fir.shape[0]))), 1024)
         s = Spectrum(fft_length=fft_length, block_length=self.fir.size,
                      step=None, fs=self.fs, wfunc=np.ones, donorm=False)
         s.periodogram(self.fir)
-        s.plot('Transfer function of FIR filter "Carrier"', fscale=fscale)
+        s.plot('Transfer function of FIR filter "Carrier"', fscale=fscale,
+               axes=axes[0])
 
         # print the frequency and the bandwidth
         if print_width:
@@ -90,15 +107,14 @@ class Carrier:
                   (f0, df, f_low, f_high, df / f0))
 
         # plots
-        if fig is None:
-            fig = plt.figure('Impulse response of FIR filter "Carrier"')
-        ax = fig.gca()
-        ax.plot(self.fir)
+        axes[1].plot(self.fir)
         if self.extract_complex:
-            ax.plot(self.fir_imag)
-        ax.set_title('Impulse response of FIR filter "Carrier"')
-        plt.xlabel('Samples')
-        plt.ylabel('Amplitude')
+            axes[1].plot(self.fir_imag)
+        axes[1].set_title('Impulse response of FIR filter "Carrier"')
+        axes[1].set_xlabel('Samples')
+        axes[1].set_ylabel('Amplitude')
+        if not fig_passed:
+            fig.tight_layout()
         return fig
 
     def direct(self, sigin):

--- a/pactools/utils/spectrum.py
+++ b/pactools/utils/spectrum.py
@@ -138,12 +138,25 @@ class Spectrum(object):
         plots the power spectral density
         warning: the plot will only appear after plt.show()
 
-        returns the figure instance
+        Parameters
+        ----------
+        title : str
+            Title of the plot (and the window).
+        fscale : str
+            Kind of frequency scale ('lin' or 'log').
+        labels : list of str
+            List of labels for the plots.
+        fig : matplotlib.Figure
+            Specific figure to plot on.
+        axes : matplotlib.Axes
+            Specific axes to draw on. Overrides `fig`.
+        replicate : int
+            Number of replication of the spectrum across frequencies
 
-        title  : title of the plot (and the window)
-        fscale : kind of frequency scale ('lin' or 'log')
-        labels : list of label of the plots
-        replicate: number of replication of the spectrum across frequencies
+        Returns
+        -------
+        fig : matplotlib.Figure
+            Figure instance used in plotting.
         """
         fft_length, _ = self.check_params()
         if labels is None:

--- a/pactools/utils/spectrum.py
+++ b/pactools/utils/spectrum.py
@@ -203,7 +203,7 @@ class Spectrum(object):
             for i in range(replicate + 1):
                 label = label_ if i == 0 else ''
                 axes.plot(freq + i * fmax, psd.T[::(-1) ** i], label=label,
-                         color=color)
+                          color=color)
 
         axes.grid(True)
         axes.set_title(title)

--- a/pactools/utils/spectrum.py
+++ b/pactools/utils/spectrum.py
@@ -133,7 +133,7 @@ class Spectrum(object):
         return psd
 
     def plot(self, title='', fscale='lin', labels=None, fig=None,
-             replicate=None, colors=None):
+             axes=None, replicate=None, colors=None):
         """
         plots the power spectral density
         warning: the plot will only appear after plt.show()
@@ -160,18 +160,27 @@ class Spectrum(object):
         if colors is None:
             colors = ('bgrcmyk' * 100)[:len(self.psd)]
 
-        if fig is None:
-            fig = plt.figure(title).gca()
-        try:
-            fig = fig.gca()
-        except:
-            pass
+        if axes is None:
+            if fig is None:
+                fig = plt.figure(title)
+                axes = fig.gca()
+            else:
+                if not isinstance(fig, plt.Figure):
+                    raise TypeError('fig must be matplotlib Figure, got {}'
+                                    ' instead.'.format(type(fig)))
+                axes = fig.gca()
+        else:
+            # validate if axes is correct
+            if not isinstance(axes, plt.Axes):
+                raise TypeError('axes must be matplotlib Axes, got {}'
+                                ' instead.'.format(type(axes)))
+            fig = axes.figure
 
         self.fscale = fscale
         if self.fscale == 'log':
-            fig.set_xscale('log')
+            axes.set_xscale('log')
         else:
-            fig.set_xscale('linear')
+            axes.set_xscale('linear')
 
         fmax = self.fs / 2
         freq = np.linspace(0, fmax, fft_length // 2 + 1)
@@ -180,15 +189,15 @@ class Spectrum(object):
             psd = 10.0 * np.log10(np.maximum(psd, 1.0e-16))
             for i in range(replicate + 1):
                 label = label_ if i == 0 else ''
-                fig.plot(freq + i * fmax, psd.T[::(-1) ** i], label=label,
+                axes.plot(freq + i * fmax, psd.T[::(-1) ** i], label=label,
                          color=color)
 
-        fig.grid(True)
-        fig.set_title(title)
-        fig.set_xlabel('Frequency (Hz)')
-        fig.set_ylabel('Amplitude (dB)')
+        axes.grid(True)
+        axes.set_title(title)
+        axes.set_xlabel('Frequency (Hz)')
+        axes.set_ylabel('Amplitude (dB)')
         if plot_legend:
-            fig.legend(loc=0)
+            axes.legend(loc=0)
         return fig
 
     def main_frequency(self):


### PR DESCRIPTION
Currently `Carrier.plot()` generates two figures, and the returned `fig` variable is the second one plotted (because the first one comes from `Spectrum.plot()`. I've modified `Carrier` and `Spectrum` plot methods a bit to allow `Carrier.plot()` to return one figure with subplots.

Sorry for compulsory checks for fig/axes params, also first two commits should refer to `Spectrum`, not `Carrier`.
I can add tests if needed.

## Before
interactive
(only that figures cover each other completely):
<img src="https://cloud.githubusercontent.com/assets/8452354/26736986/94f1d08c-47c8-11e7-8ac8-ad6a25316cfa.PNG" width="500">

inline:
<img src="https://cloud.githubusercontent.com/assets/8452354/26736994/a3163ba8-47c8-11e7-9fd5-fb98af5b8db8.PNG" height="500">

## After
interactive:
<img src="https://cloud.githubusercontent.com/assets/8452354/26737004/ab32cb62-47c8-11e7-8a30-f5a02119b222.PNG" width="400">

inline:
<img src="https://cloud.githubusercontent.com/assets/8452354/26737010/b0c5e190-47c8-11e7-9b72-d416b14b8bba.PNG" height="350">
