### PR TITLE
Better surrogate

### DIFF
--- a/examples/plot_surrogate_analysis.py
+++ b/examples/plot_surrogate_analysis.py
@@ -35,7 +35,7 @@ low_fq = 5.0  # Hz
 low_fq_width = 1.0  # Hz
 
 n_points = 1000
-noise_level = 0.3
+noise_level = 0.4
 
 signal = simulate_pac(n_points=n_points, fs=fs, high_fq=high_fq, low_fq=low_fq,
                       low_fq_width=low_fq_width, noise_level=noise_level,
@@ -45,7 +45,7 @@ signal = simulate_pac(n_points=n_points, fs=fs, high_fq=high_fq, low_fq=low_fq,
 # Then, let's define the range of low frequency, and the PAC metric used.
 
 low_fq_range = np.linspace(1, 10, 50)
-method = 'duprelatour'  # or 'tort', 'ozkurt', 'penny', ...
+method = 'duprelatour'  # or 'tort', 'ozkurt', 'penny', 'colgin', ...
 
 # We also choose the number of comodulograms computed in the surrogate
 # analysis. A good rule of thumb is 10 / p_value. Example: 10 / 0.05 = 200.

--- a/examples/plot_surrogate_analysis.py
+++ b/examples/plot_surrogate_analysis.py
@@ -1,0 +1,114 @@
+"""
+Surrogate analysis
+------------------
+This example shows how to estimate a significance threshold in a comodulogram.
+
+A comodulogram shows the estimated PAC metric on a grid of frequency bands.
+In absence of PAC, a PAC metric will return values close to zero, but not
+exactly zero. To estimate if a value is significantly far from zero, we use a
+surrogate analysis.
+
+In a surrogate analysis, we recompute the comodulogram many times, adding each
+time a random time shift to remove any possible coupling between the
+components. Nota that these time shifts have to be far from zero to effectively
+remove a potential coupling. These comodulograms give us an estimation of the
+fluctuation of the metric in the absence of PAC.
+
+To derive a significance level from the list of comodulograms, we discuss here
+two different methods:
+- Computing a z-score on each couple of frequency, and thresholding at z = 4.
+- Computing a threshold at a given p-value, over a distribution of comodulogram
+maxima.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+
+from pactools import Comodulogram
+from pactools import simulate_pac
+
+###############################################################################
+# Let's first create an artificial signal with PAC.
+
+fs = 200.  # Hz
+high_fq = 50.0  # Hz
+low_fq = 5.0  # Hz
+low_fq_width = 1.0  # Hz
+
+n_points = 1000
+noise_level = 0.3
+
+signal = simulate_pac(n_points=n_points, fs=fs, high_fq=high_fq, low_fq=low_fq,
+                      low_fq_width=low_fq_width, noise_level=noise_level,
+                      random_state=0)
+
+###############################################################################
+# Then, let's define the range of low frequency, and the PAC metric used.
+
+low_fq_range = np.linspace(1, 10, 50)
+method = 'duprelatour'  # or 'tort', 'ozkurt', 'penny', ...
+
+# We also choose the number of comodulograms computed in the surrogate
+# analysis. A good rule of thumb is 10 / p_value. Example: 10 / 0.05 = 200.
+n_surrogates = 200
+
+# As a surrogate analysis recquires to compute many comodulograms, the
+# computation can be slow. If you have multiple cores in your CPU, you can
+# leverage them using the parameter `n_jobs` > 1.
+n_jobs = 1
+
+###############################################################################
+# To compute the comodulogram, we need to instanciate a `Comodulogram` object,
+# then call the method `fit`. Adding the surrogate analysis is as simple as
+# adding the `n_surrogates` parameter.
+
+estimator = Comodulogram(fs=fs, low_fq_range=low_fq_range,
+                         low_fq_width=low_fq_width, method=method,
+                         n_surrogates=n_surrogates, progress_bar=True,
+                         n_jobs=n_jobs)
+estimator.fit(signal)
+
+###############################################################################
+# Then we plot the significance level on top of the comodulogram.
+# Here we present two methods.
+#
+# The z-score method presented here considers independently each pair of
+# frequency of the comodulogram. For each pair, we compute the mean `mu` and
+# standard deviation `sigma` of the PAC values computed over the surrogates
+# signals. We then transform the original PAC values `PAC` (non time-shifted)
+# into z-scores `Z`: Z = (PAC - mu) / sigma
+#
+# This procedure, used for example in [Canolty et al, 2006], suffers from
+# multiple-testing issues, and also assumes that the distribution of PAC values
+# is Gaussian.
+#
+#
+# The other method presented here considers the ditribution of comodulogram
+# maxima. For each surrogate comodulogram, we compute the maximum PAC value.
+# From the obtained empirical distribution of maxima, we compute the
+# 95-percentile, which corresponds to a p-value of 0.05.
+#
+# This method does not assume the distribution to be Gaussian, nor suffers from
+# multiple-testing issues. This is the default method in the `plot` method.
+
+fig, axs = plt.subplots(1, 2, figsize=(10, 4))
+
+z_score = 4.
+estimator.plot(contour_method='z_score', contour_level=z_score,
+               titles=['With a z-score on each couple of frequency'],
+               axs=[axs[0]])
+
+p_value = 0.05
+estimator.plot(contour_method='comod_max', contour_level=p_value,
+               titles=['With a p-value on the distribution of maxima'],
+               axs=[axs[1]])
+
+plt.show()
+
+###############################################################################
+# References
+#
+# [Canolty et al, 2006]
+# Canolty, R. T., Edwards, E., Dalal, S. S., Soltani, M., Nagarajan,
+# S. S., Kirsch, H. E., ... & Knight, R. T. (2006). High gamma power is
+# phase-locked to theta oscillations in human neocortex. science,
+# 313(5793), 1626-1628.

--- a/pactools/comodulogram.py
+++ b/pactools/comodulogram.py
@@ -225,7 +225,7 @@ class Comodulogram(object):
             mask = [check_array(m, dtype=bool, accept_none=True) for m in mask]
         n_masks = len(mask)
 
-        # pre compute all the random time shifts
+        # pre-compute all the random time shifts
         n_epochs, n_points = low_sig.shape
         self.shifts_ = _get_shifts(self.random_state, n_points,
                                    self.minimum_shift, self.fs,
@@ -1097,20 +1097,5 @@ def _surrogate_analysis(comod_function, function_kwargs, shifts):
     for sh in shifts:
         comod_list.append(comod_function(shift=sh, **function_kwargs))
     comod_list = np.array(comod_list)
-
-    # # the first has no shift
-    # comod = comod_list[0, ...]
-
-    # # here we compute the z-score
-    # comod_z_score, surrogate_max = None, None
-    # if shifts.size > 2:
-    #     comod_z_score = comod.copy()
-    #     comod_z_score -= np.mean(comod_list[1:, ...], axis=0)
-    #     comod_z_score /= np.std(comod_list[1:, ...], axis=0)
-    #
-    #     tmp = comod_list[1:]
-    #     tmp = tmp.reshape(tmp.shape[0], -1)
-    #     surrogate_max = np.max(tmp, axis=1)
-    #     assert surrogate_max.size == shifts.size - 1
 
     return comod_list

--- a/pactools/comodulogram.py
+++ b/pactools/comodulogram.py
@@ -328,11 +328,7 @@ class Comodulogram(object):
 
         comod_ = self.comod_.copy()
         surrogates_ = self.surrogates_
-        if surrogates_ is None:
-            raise ValueError(
-                "Impossible to compute comod_z_score_ since the surrogate "
-                "comodulograms were not computed. Try to refit the "
-                "estimator with n_surrogates > 2.")
+
         ndim = surrogates_.ndim
         if ndim == 3:
             surrogates_ = surrogates_[None, ...]
@@ -347,7 +343,10 @@ class Comodulogram(object):
                 comod_z_score = comod_z_score[0]
             return comod_z_score
         else:
-            return None
+            raise ValueError(
+                "Impossible to compute comod_z_score_ since the surrogate "
+                "comodulograms were not computed. Try to refit the "
+                "estimator with n_surrogates > 1.")
 
     @property
     def surrogate_max_(self):
@@ -360,13 +359,8 @@ class Comodulogram(object):
             be: shape (n_masks, n_surrogates)
         """
         check_is_fitted(self, 'surrogates_')
-
         surrogates_ = self.surrogates_
-        if surrogates_ is None:
-            raise ValueError(
-                "Impossible to compute surrogate_max_ since the surrogate "
-                "comodulograms were not computed. Try to refit the "
-                "estimator with n_surrogates > 2.")
+
         ndim = surrogates_.ndim
         if ndim == 3:
             surrogates_ = surrogates_[None, ...]
@@ -380,7 +374,10 @@ class Comodulogram(object):
                 surrogate_max = surrogate_max[0]
             return surrogate_max
         else:
-            return None
+            raise ValueError(
+                "Impossible to compute comod_z_score_ since the surrogate "
+                "comodulograms were not computed. Try to refit the "
+                "estimator with n_surrogates > 1.")
 
     def plot(self, titles=None, axs=None, cmap=None, vmin=None, vmax=None,
              unit='', cbar=True, label=True, contour_level=None,
@@ -426,6 +423,11 @@ class Comodulogram(object):
 
         tight_layout : boolean
             Use tight_layout or not
+
+        Returns
+        -------
+        fig: matplotlib.figure.Figure
+            The figure object
         """
         check_is_fitted(self, 'comod_')
         comod_ = self.comod_
@@ -503,7 +505,7 @@ class Comodulogram(object):
                     levels = np.atleast_1d(
                         np.percentile(surrogate_max_[i], percentiles))
 
-                    axs[i].contour(self.comod_[i].T, levels=levels, colors='w',
+                    axs[i].contour(comod_[i].T, levels=levels, colors='w',
                                    origin='lower', extent=extent)
                 elif contour_method == 'z_score':
                     levels = np.atleast_1d(contour_level)

--- a/pactools/utils/parallel.py
+++ b/pactools/utils/parallel.py
@@ -1,0 +1,31 @@
+import warnings
+
+
+class _FakeParallel(object):
+    """Useless decorator that is used like Parallel"""
+    def __init__(self, n_jobs=1, *args, **kwargs):
+        if n_jobs != 1:
+            warnings.warn(
+                "You have set n_jobs=%s to use parallel processing, "
+                "but it has currently no effect. Please install joblib or "
+                "scikit-learn to use it."
+                % (n_jobs, ))
+
+    def __call__(self, iterable):
+
+        return list(iterable)
+
+
+def _fake_delayed(func):
+    return func
+
+
+# try to import from joblib, otherwise, create a dummy function with no effect
+try:
+    from joblib import Parallel, delayed
+except ImportError:
+    try:
+        from sklearn.externals.joblib import Parallel, delayed
+    except ImportError:
+        Parallel = _FakeParallel
+        delayed = _fake_delayed

--- a/pactools/utils/progress_bar.py
+++ b/pactools/utils/progress_bar.py
@@ -114,3 +114,12 @@ class ProgressBar():
             sys.stdout.write('\n')
             sys.stdout.flush()
             self.closed = True
+
+    def __call__(self, sequence):
+        while True:
+            try:
+                yield next(sequence)
+                self.update_with_increment_value(1)
+            except StopIteration:
+                self.close()
+                return

--- a/pactools/utils/progress_bar.py
+++ b/pactools/utils/progress_bar.py
@@ -121,5 +121,4 @@ class ProgressBar():
                 yield next(sequence)
                 self.update_with_increment_value(1)
             except StopIteration:
-                self.close()
                 return

--- a/pactools/utils/tests/test_parallel.py
+++ b/pactools/utils/tests/test_parallel.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from pactools.utils.parallel import _FakeParallel, _fake_delayed
+from pactools.utils.testing import assert_array_equal, assert_equal
+
+
+def twice(a):
+    return 2 * a
+
+
+def test_fake_parallel():
+    # Test that _FakeParallel does nothing but unrolling the generator
+    generator = (twice(b) for b in range(10))
+    results = _FakeParallel(n_jobs=1)(generator)
+    reference = [twice(b) for b in range(10)]
+    assert_array_equal(np.array(results), np.array(reference))
+
+    # test fake parameters
+    _FakeParallel(n_jobs=1, foo='bar', baz=42)
+
+
+def test_fake_delayed():
+    # Test that fake_delayed does nothing but returning the input arg
+    assert_equal(twice, _fake_delayed(twice))
+    assert_equal(42, _fake_delayed(42))


### PR DESCRIPTION
This PR implements a different kind of surrogate analysis, computing a threshold at a given p-value over a distribution of comodulogram maxima.
The previous one was computing a z-score on each couple of frequency, which was not satisfactory since it suffers from multiple-testing issues, and also assumes that the distribution of PAC values is Gaussian.

The details is explained in `examples/plot_surrogate_analysis.py`.
___
I also refactored a bit to be able to have a cleaner code and a faster parallel implementation.

